### PR TITLE
Support temporary use of local spec for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,14 +93,18 @@ crio.conf: crio
 tarball-prep:
 	git archive --format=tar.gz --prefix=cri-o-testonly/ HEAD > ../cri-o-testonly_1.8.0.orig.tar.gz
 
-# FIXME! Assumption check: this assumes that 'make test-rpm' is invoked
-#        from the git root. The '../' in tarball-prep above leads me
-#        to wonder if that assumption holds. Please review carefully.
 test-rpm: tarball-prep
-	sudo ./contrib/rpm/make-testonly-rpms			\
-		../cri-o-testonly_1.8.0.orig.tar.gz		\
-		https://src.fedoraproject.org/rpms/cri-o.git	\
-		pull/1/head
+	if [ -r "$(CURDIR)/*.spec" ]; then
+		# Note: Assumes $(CURDIR) is a git repository clone
+		sudo ./contrib/rpm/make-testonly-rpms           \
+            ../cri-o-testonly_1.8.0.orig.tar.gz        \
+			$(CURDIR)
+	else
+		sudo ./contrib/rpm/make-testonly-rpms			\
+			../cri-o-testonly_1.8.0.orig.tar.gz		\
+			https://src.fedoraproject.org/rpms/cri-o.git	\
+			pull/1/head
+	fi
 
 test-deb: tarball-prep
 	sudo apt-add-repository -y ppa:projectatomic/ppa
@@ -110,7 +114,7 @@ test-deb: tarball-prep
 	dpkg-buildpackage -us -uc
 
 clean-rpm:
-	rm -rf cri-o*.rpm cri-o-testonly*.tar.gz
+	rm -rf cri-o*.rpm ../cri-o-testonly*.tar.gz
 
 clean-deb:
 	rm -rf debian/cri-o ../*ppa*


### PR DESCRIPTION
Allow developers to drop temporary packaging details
to support local testing w/o the need to coordinate with
remote repositories.  This is not intended for permanent/production
use, only short-term, local development.

Signed-off-by: Chris Evich <cevich@redhat.com>